### PR TITLE
Fix: Readme Zod link

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@
 
 ---
 ### 📚 Tutorial References
-- 🔗 [Zod Official Site](https://nextjs.org/)
+- 🔗 [Zod Official Site](https://zod.dev/)
 - 🔗 [React-Hook-Form](https://www.react-hook-form.com/)
 - 🔗 [NPM: @hookform/resolvers](https://www.npmjs.com/package/@hookform/resolvers)
 - 🔗 [{JSON} Placeholder](https://jsonplaceholder.typicode.com/)


### PR DESCRIPTION
Zod link in README goes to Nextjs page instead of https://zod.dev/.